### PR TITLE
Update viewer.js

### DIFF
--- a/wwwroot/viewer.js
+++ b/wwwroot/viewer.js
@@ -13,8 +13,11 @@ async function getAccessToken(callback) {
 
 export function initViewer(container) {
     return new Promise(function (resolve, reject) {
-        Autodesk.Viewing.Initializer({ getAccessToken }, async function () {
-            const viewer = new Autodesk.Viewing.GuiViewer3D(container);
+        Autodesk.Viewing.Initializer({ getAccessToken }, function () {
+            const config = {
+                extensions: ['Autodesk.DocumentBrowser']
+            };
+            const viewer = new Autodesk.Viewing.GuiViewer3D(container, config);
             viewer.start();
             viewer.setTheme('light-theme');
             resolve(viewer);


### PR DESCRIPTION
Added configuration to viewer to match the aps-simple-viewer tutorial. During the bootcamp, people were asking how to add the document browser extension like they did with the aps-simple viewer tutorial.